### PR TITLE
Adjustments/fixes in the "Clinvar pathogenic" filter (#464)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,9 @@ End-User Summary
 - Small extension of "Resolution proposal" template (#472).
 - Adjusting wrong release name to "anthenea" (#479).
 - Adding "show all variant carriers" feature (#470).
+- Properly display the clinvar annotations that we have in the database (#464).
+- Adjusting default frequency filters for "clinvar pathogenic" filter: remove all threshold (#464).
+- Adding note about difference with upstream Clinvar (#464).
 
 Full Change List
 ================
@@ -35,6 +38,9 @@ Full Change List
 - Small extension of "Resolution proposal" template (#472).
 - Adjusting wrong release name to "anthenea" (#479).
 - Adding "show all variant carriers" feature (#470).
+- Properly display the clinvar annotations that we have in the database (#464).
+- Adjusting default frequency filters for "clinvar pathogenic" filter: remove all threshold (#464).
+- Adding note about difference with upstream Clinvar (#464).
 
 ------
 v1.2.0

--- a/varfish/static/js/filter_form.js
+++ b/varfish/static/js/filter_form.js
@@ -1873,7 +1873,7 @@ function loadPresets(element) {
     $("#input-presets-flags").val("flags-default")
   } else if (presetsName == "clinvar") {
     $("#input-presets-inheritance").val("inheritance-mitochondrial")
-    $("#input-presets-frequency").val("frequency-recessive-relaxed")
+    $("#input-presets-frequency").val("frequency-all")
     $("#input-presets-impact").val("impact-any")
     $("#input-presets-quality").val("quality-strict")
     $("#input-presets-region").val("region-whole-genome")

--- a/variants/query_presets.py
+++ b/variants/query_presets.py
@@ -1049,7 +1049,7 @@ class _QuickPresetList:
     #: Clinvar pathogenic presets
     clinvar_pathogenic: QuickPresets = QuickPresets(
         inheritance=Inheritance.AFFECTED_CARRIERS,
-        frequency=Frequency.RECESSIVE_RELAXED,
+        frequency=Frequency.ANY,
         impact=Impact.ANY,
         quality=Quality.STRICT,
         chromosomes=Chromosomes.WHOLE_GENOME,

--- a/variants/templates/variants/filter_result/header.html
+++ b/variants/templates/variants/filter_result/header.html
@@ -68,7 +68,7 @@
   <th class="detail-info-coordinates">ref</th>
   <th class="detail-info-coordinates">alt</th>
   <th class="detail-info-clinvar">sign.&nbsp;&amp;&nbsp;rating</th>
-  <th class="detail-info-clinvar">phenotype</th>
+  <th class="detail-info-clinvar"></th>
   <th class="detail-info-clinvar p-0"></th>
   <th class="detail-frequencies-exac">frequency</th>
   <th class="detail-frequencies-gnomad-exomes">frequency</th>

--- a/variants/templates/variants/filter_result/row.html
+++ b/variants/templates/variants/filter_result/row.html
@@ -86,14 +86,14 @@
     </div>
   </td>
   <td style="width: 50px;" class="pl-2 detail-info-clinvar" data-order="{% if entry.max_significance %}{{ entry.max_significance|significance_importance }}-{{ entry.max_clinvar_status|status_importance }}{% else %}9-9{% endif %}">
-    {% if entry.max_significance %}
+    {% if entry.pathogenicity %}
         <span class="badge-group">
-          <span class="badge badge-{{ entry.max_significance|significance_color }}">
-            {{ entry.max_significance|significance_text }}
+          <span class="badge badge-{{ entry.pathogenicity|significance_color }}">
+            {{ entry.pathogenicity }}
           </span>
           <span class="badge badge-dark" data-toggle="tooltip" data-placement="top" title="{{ entry.max_clinvar_status }}">
             {% for i in "1234" %}
-              {% if forloop.counter <= entry.max_clinvar_status|status_stars %}
+              {% if forloop.counter <= entry.point_rating %}
                 <i class="iconify" data-icon="fa-solid:star"></i>
               {% else %}
                 <i class="iconify" data-icon="fa-regular:star"></i>
@@ -106,13 +106,6 @@
     {% endif %}
   </td>
   <td style="max-width: 80px;" class="pl-2 detail-info-clinvar">
-    <div class="sodar-overflow-container sodar-overflow-hover">
-        {% if entry.max_all_traits %}
-            {{ entry.max_all_traits|join:"; " }}
-        {% else %}
-            -
-        {% endif %}
-    </div>
   </td>
   <td class="detail-info-clinvar p-0"></td>
   <td class="detail-frequencies-exac">

--- a/variants/templates/variants/var_details/clinvar.html
+++ b/variants/templates/variants/var_details/clinvar.html
@@ -6,6 +6,11 @@
     <h4 class="card-title">ClinVar for Variant</h4>
     <small><a href="https://www.ncbi.nlm.nih.gov/clinvar/?term={{ clinvar.vcv }}" target="_blank">{{ clinvar.vcv }}</a></small>
   </div>
+  <div class="text-muted small p-2">
+    <span class="iconify" data-icon="mdi:information" data-inline="false"></span>
+    Note that VarFish is using a local copy of Clinvar to display this information.
+    The link-outs to NCBI ClinVar will display the most current data that may differ from our "frozen" copy.
+  </div>
   <ul class="list-group list-group-flush">
     {% for cv in clinvar.details %}
       <li class="list-group-item flex-column align-items-start border-top px-2 list-group-item-action">

--- a/variants/tests/test_query_presets.py
+++ b/variants/tests/test_query_presets.py
@@ -1530,7 +1530,7 @@ class TestQuickPresets(PedigreesMixin, TestCase):
         self.assertEqual(
             str(query_presets.QUICK_PRESETS.clinvar_pathogenic),
             "QuickPresets(inheritance=<Inheritance.AFFECTED_CARRIERS: 'affected_carriers'>, "
-            "frequency=<Frequency.RECESSIVE_RELAXED: 'recessive_relaxed'>, impact=<Impact.ANY: 'any'>, "
+            "frequency=<Frequency.ANY: 'any'>, impact=<Impact.ANY: 'any'>, "
             "quality=<Quality.STRICT: 'strict'>, chromosomes=<Chromosomes.WHOLE_GENOME: 'whole_genome'>, "
             "flags_etc=<FlagsEtc.CLINVAR_ONLY: 'clinvar_only'>, database=<Database.REFSEQ: 'refseq'>)",
         )


### PR DESCRIPTION
Properly display the clinvar annotations that we have in the database (#464).
Adjusting default frequency filters for "clinvar pathogenic" filter: remove all threshold (#464).
Adding note about difference with upstream Clinvar (#464).

Related-Issue: #464
Closes: #464
Projected-Results-Impact: require-revalidation