### PR TITLE
Extra annotations in export completed and tested

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ End-User Summary
 - Starting with development of Bollonaster (VarFish v2)
 - Documenting problem with extra annotations in ``20210728` data release (#450).
   Includes instructions on how to apply patch to get ``20210728b``.
+- Extra annotations in export completed and tested (#495).
 - Removing problematic username modification behaviour on login page (#459).
 - Displaying login page text from settings again (#458).
 - Suppress "submit to CADD" and "submit to SPANR" buttons for multi-case form (#478).

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -553,9 +553,6 @@ VARFISH_UMD_REST_API_URL = env.str(
     "VARFISH_UMD_REST_API_URL", "http://umd-predictor.eu/webservice.php"
 )
 
-# Varfish: extra annotations.
-VARFISH_ENABLE_EXTRA_ANNOS = env.bool("VARFISH_ENABLE_EXTRA_ANNOS", False)
-
 # Varfish: Jannovar
 # ------------------------------------------------------------------------------
 

--- a/variants/templates/variants/variant_details.html
+++ b/variants/templates/variants/variant_details.html
@@ -15,7 +15,6 @@
 {% block projectroles_extend %}
   {% get_app_setting "variants" "ga4gh_beacon_network_widget_enabled" user=user as ga4gh_beacon_network_widget_enabled %}
   {% get_django_setting "PROJECTROLES_KIOSK_MODE" as kiosk_mode %}
-  {% get_django_setting "VARFISH_ENABLE_EXTRA_ANNOS" as extra_annos_enabled %}
 
   <div style="font-size: .9em;">
     <div class="row">
@@ -31,9 +30,7 @@
         {% endif %}
         {% include "variants/var_details/clinvar.html" %}
         {% include "variants/var_details/freq_overview.html" %}
-        {% if extra_annos_enabled %}
-          {% include "variants/var_details/extra_annos.html" %}
-        {% endif %}
+        {% include "variants/var_details/extra_annos.html" %}
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Closes: https://github.com/bihealth/varfish-server/issues/495
Related-Issue: https://github.com/bihealth/varfish-server/issues/495
Project-Results-Impact: none

These are the changes required to export extra_annotation table to xls and tsv.

Tests are included

P.S. Not so sure how test with and without Extra Anno active. So please note

VARFISH_ENABLE_EXTRA_ANNOS = env.bool("VARFISH_ENABLE_EXTRA_ANNOS", True)

That would change the default setting.

Otherwise the code is pretty straighforward there is 

RowWithExtraAnno that wrap the result table in order to make the exporters working with the additional columns.

The additional columns are added in the base exported when extra anno option is active, the expansion is based on the fields in the database
