### PR TITLE
fix: Remove IGV prefixing

### DIFF
--- a/variants/vueapp/src/components/VariantDetails/VariantTools.vue
+++ b/variants/vueapp/src/components/VariantDetails/VariantTools.vue
@@ -222,11 +222,8 @@ const umdpredictorLinkout = computed((): string => {
 })
 
 const jumpToLocus = async () => {
-  const chrPrefixed = props.smallVar.chromosome.startsWith('chr')
-    ? props.smallVar.chromosome
-    : `chr${props.smallVar.chromosome}`
   await fetch(
-    `http://127.0.0.1:60151/goto?locus=${chrPrefixed}:${props.smallVar.start}-${props.smallVar.end}`,
+    `http://127.0.0.1:60151/goto?locus=${props.smallVar.chromosome}:${props.smallVar.start}-${props.smallVar.end}`,
   ).catch((e) => {
     const msg =
       "Couldn't connect to IGV. Please make sure IGV is running and try again."


### PR DESCRIPTION
Currently `chr` is prefixed to any chromosomal label. This does not seem necessary for currently used `b37`. Why was this done in the first place? Just in case reverting this might break anything.

Also the current approach would mess up patched locations etc, as strings are not checked whether prefixing actually is sensible or not.